### PR TITLE
Exchange tests

### DIFF
--- a/tests/testthat/test_plots.R
+++ b/tests/testthat/test_plots.R
@@ -53,10 +53,9 @@ test_that("Behavior of the other plots", {
   expect_visible(sankeyLand(demo_cont$lulc_Multistep, demo_cont$tb_legend))
 
 
-
-  expect_output(str(barplotLand(demo_cont$lulc_Multistep, demo_cont$tb_legend)), "List of 9")
+  expect_s3_class(barplotLand(demo_cont$lulc_Multistep, demo_cont$tb_legend), "ggplot")
   #expect_null(str(chordDiagramLand(demo_cont$lulc_Onestep, demo_cont$tb_legend)))
-  expect_output(str(netgrossplot(demo_cont$lulc_Multistep, demo_cont$tb_legend)), "List of 9")
+  expect_s3_class(netgrossplot(demo_cont$lulc_Multistep, demo_cont$tb_legend), "ggplot")
   expect_output(str(sankeyLand(demo_cont$lulc_Onestep, demo_cont$tb_legend)), "List of 8")
   expect_output(str(sankeyLand(demo_cont$lulc_Multistep, demo_cont$tb_legend)), "List of 8")
 


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break OpenLand.

Briefly, testing the `str()` output of a ggplot-based object is brittle, as it might change as ggplot2's internals change.
This PR changes these tests by a simple test of whether the output is a ggplot object.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help OpenLand get out a fix if necessary.