### PR TITLE
Add `changes` global

### DIFF
--- a/R/contingencyTable.R
+++ b/R/contingencyTable.R
@@ -1,5 +1,5 @@
 utils::globalVariables(c("Interval", "Period", "Year_from",
-                         "Year_to", "strings01", "strings02"))
+                         "Year_to", "strings01", "strings02", "changes"))
 
 #' @include demolandscape.R rasters_input.R
 NULL


### PR DESCRIPTION
Hi there, we are working on the next version of dplyr and your package was flagged in our reverse dependency checks.

We have removed the defunct function `dplyr::changes()`.

Your package does one of two things:

- It re-exports `dplyr::changes()`, which has been defunct for many years and has now been removed from dplyr.

- It references a column named `changes`, likely in a `mutate()` or `summarise()`, but does not note this as a global variable with `utils::globalVariables("changes")`. In this case, you got lucky that dplyr exported `changes()`, meaning that you did not need a global variable for `"changes"`. Since we have removed `dplyr::changes()`, your package will need this now.

dplyr will be released on January 31, 2026. If you could please send an update of your package to CRAN before then, that would help us out a lot! Thanks!